### PR TITLE
Make Barched work with Sable & Fix Elytra Lunging

### DIFF
--- a/common/src/main/java/zzik2/barched/bridge/client/LocalPlayerBridge.java
+++ b/common/src/main/java/zzik2/barched/bridge/client/LocalPlayerBridge.java
@@ -1,11 +1,12 @@
 package zzik2.barched.bridge.client;
 
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.HitResult;
 
 public interface LocalPlayerBridge {
 
-    default HitResult raycastHitResult(float f, Entity entity) {
+    default HitResult raycastHitResult(GameRenderer renderer, float f, Entity entity) {
         return null;
     }
 }

--- a/common/src/main/java/zzik2/barched/mixin/accessor/client/renderer/GameRendererAccessor.java
+++ b/common/src/main/java/zzik2/barched/mixin/accessor/client/renderer/GameRendererAccessor.java
@@ -1,0 +1,14 @@
+package zzik2.barched.mixin.accessor.client.renderer;
+
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.HitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(GameRenderer.class)
+public interface GameRendererAccessor {
+
+    @Invoker("pick")
+    HitResult barched$pick(Entity entity, double blockInteractionRange, double entityInteractionRange, float partialTicks);
+}

--- a/common/src/main/java/zzik2/barched/mixin/client/multiplayer/ClientLevelMixin.java
+++ b/common/src/main/java/zzik2/barched/mixin/client/multiplayer/ClientLevelMixin.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import zzik2.barched.bridge.level.LevelBridge;
 
 @Mixin(ClientLevel.class)
@@ -35,6 +36,7 @@ public abstract class ClientLevelMixin implements LevelBridge {
 
     }
 
+    @Unique
     private void playSound(double d, double e, double f, SoundEvent soundEvent, SoundSource soundSource, float g, float h, boolean bl, long l) {
         double i = this.minecraft.gameRenderer.getMainCamera().getPosition().distanceToSqr(d, e, f);
         SimpleSoundInstance simpleSoundInstance = new SimpleSoundInstance(soundEvent, soundSource, g, h, RandomSource.create(l), d, e, f);

--- a/common/src/main/java/zzik2/barched/mixin/client/player/LocalPlayerMixin.java
+++ b/common/src/main/java/zzik2/barched/mixin/client/player/LocalPlayerMixin.java
@@ -2,17 +2,15 @@ package zzik2.barched.mixin.client.player;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.mojang.authlib.GameProfile;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySelector;
-import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.AttackRange;
 import net.minecraft.world.item.component.UseEffects;
@@ -22,6 +20,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import zzik2.barched.Barched;
+import zzik2.barched.mixin.accessor.client.renderer.GameRendererAccessor;
 import zzik2.barched.bridge.client.LocalPlayerBridge;
 import zzik2.barched.bridge.entity.LivingEntityBridge;
 
@@ -76,7 +75,7 @@ public abstract class LocalPlayerMixin extends AbstractClientPlayer implements L
     }
 
     @Override
-    public HitResult raycastHitResult(float f, Entity entity) {
+    public HitResult raycastHitResult(GameRenderer renderer, float f, Entity entity) {
         ItemStack itemStack = this.getActiveItem();
         AttackRange attackRange = (AttackRange)itemStack.get(Barched.DataComponents.ATTACK_RANGE);
         double d = this.blockInteractionRange();
@@ -89,30 +88,10 @@ public abstract class LocalPlayerMixin extends AbstractClientPlayer implements L
         }
 
         if (hitResult == null || hitResult.getType() == HitResult.Type.MISS) {
-            double e = this.entityInteractionRange();
-            hitResult = pick(entity, d, e, f);
+            hitResult = ((GameRendererAccessor) renderer).barched$pick(entity, d, this.entityInteractionRange(), f);
         }
 
         return hitResult;
-    }
-
-    private static HitResult pick(Entity entity, double d, double e, float f) {
-        double g = Math.max(d, e);
-        double h = Mth.square(g);
-        Vec3 vec3 = entity.getEyePosition(f);
-        HitResult hitResult = entity.pick(g, f, false);
-        double i = hitResult.getLocation().distanceToSqr(vec3);
-        if (hitResult.getType() != HitResult.Type.MISS) {
-            h = i;
-            g = Math.sqrt(i);
-        }
-
-        Vec3 vec32 = entity.getViewVector(f);
-        Vec3 vec33 = vec3.add(vec32.x * g, vec32.y * g, vec32.z * g);
-        float j = 1.0F;
-        AABB aABB = entity.getBoundingBox().expandTowards(vec32.scale(g)).inflate(1.0D, 1.0D, 1.0D);
-        EntityHitResult entityHitResult = ProjectileUtil.getEntityHitResult(entity, vec3, vec33, aABB, EntitySelector.NO_SPECTATORS.and(Entity::isPickable), h);
-        return entityHitResult != null && entityHitResult.getLocation().distanceToSqr(vec3) < i ? filterHitResult(entityHitResult, vec3, e) : filterHitResult(hitResult, vec3, d);
     }
 
     private static HitResult filterHitResult(HitResult hitResult, Vec3 vec3, double d) {

--- a/common/src/main/java/zzik2/barched/mixin/client/renderer/GameRendererMixin.java
+++ b/common/src/main/java/zzik2/barched/mixin/client/renderer/GameRendererMixin.java
@@ -2,6 +2,8 @@ package zzik2.barched.mixin.client.renderer;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.AttackRange;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.HitResult;
 import org.spongepowered.asm.mixin.Final;
@@ -10,6 +12,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import zzik2.barched.bridge.client.LocalPlayerBridge;
+import zzik2.barched.Barched.DataComponents;
 
 @Mixin(GameRenderer.class)
 public abstract class GameRendererMixin {
@@ -18,6 +21,12 @@ public abstract class GameRendererMixin {
 
     @Redirect(method = "pick(F)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;pick(Lnet/minecraft/world/entity/Entity;DDF)Lnet/minecraft/world/phys/HitResult;"))
     private HitResult barched$pick(GameRenderer instance, Entity entity, double d, double e, float f) {
+        ItemStack itemStack = this.minecraft.player == null ? ItemStack.EMPTY : this.minecraft.player.getMainHandItem();
+        AttackRange attackRange = (AttackRange)itemStack.get(DataComponents.ATTACK_RANGE);
+        if (attackRange == null) {
+            return entity.pick(Math.max(d, e), f, false);
+        }
+
         return ((LocalPlayerBridge) this.minecraft.player).raycastHitResult(f, entity);
     }
 }

--- a/common/src/main/java/zzik2/barched/mixin/client/renderer/GameRendererMixin.java
+++ b/common/src/main/java/zzik2/barched/mixin/client/renderer/GameRendererMixin.java
@@ -2,8 +2,6 @@ package zzik2.barched.mixin.client.renderer;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.AttackRange;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.HitResult;
 import org.spongepowered.asm.mixin.Final;
@@ -12,7 +10,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import zzik2.barched.bridge.client.LocalPlayerBridge;
-import zzik2.barched.Barched.DataComponents;
 
 @Mixin(GameRenderer.class)
 public abstract class GameRendererMixin {
@@ -21,12 +18,6 @@ public abstract class GameRendererMixin {
 
     @Redirect(method = "pick(F)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;pick(Lnet/minecraft/world/entity/Entity;DDF)Lnet/minecraft/world/phys/HitResult;"))
     private HitResult barched$pick(GameRenderer instance, Entity entity, double d, double e, float f) {
-        ItemStack itemStack = this.minecraft.player == null ? ItemStack.EMPTY : this.minecraft.player.getMainHandItem();
-        AttackRange attackRange = (AttackRange)itemStack.get(DataComponents.ATTACK_RANGE);
-        if (attackRange == null) {
-            return entity.pick(Math.max(d, e), f, false);
-        }
-
-        return ((LocalPlayerBridge) this.minecraft.player).raycastHitResult(f, entity);
+        return ((LocalPlayerBridge) this.minecraft.player).raycastHitResult(instance, f, entity);
     }
 }

--- a/common/src/main/java/zzik2/barched/mixin/entity/LivingEntityMixin.java
+++ b/common/src/main/java/zzik2/barched/mixin/entity/LivingEntityMixin.java
@@ -106,7 +106,7 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityBr
         int i = ((ItemStackBridge) (Object) itemStack).getSwingAnimation().duration();
         return i;
     }
-    
+
     @Override
     public void lungeForwardMaybe() {
         barched$lungeForwardMaybe();
@@ -119,6 +119,10 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityBr
 
     @Unique
     public void barched$lungeForwardMaybe() {
+        if (((LivingEntity)(Object)this).isFallFlying()) {
+            return;
+        }
+
         Level var2 = this.level();
         if (var2 instanceof ServerLevel) {
             ServerLevel serverLevel = (ServerLevel)var2;

--- a/common/src/main/resources/barched.mixins.json
+++ b/common/src/main/resources/barched.mixins.json
@@ -6,6 +6,7 @@
   "minVersion": "0.8",
   "client": [
     "accessor.client.HumanoidModelAccessor",
+    "accessor.client.renderer.GameRendererAccessor",
     "client.GuiMixin",
     "client.HumanoidModel$ArmPoseMixin",
     "client.MinecraftMixin",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -5,7 +5,8 @@
   "name": "Barched",
   "description": "Bringing Parched, Camel Husk and Spears from 1.21.11 to 1.21.1!",
   "authors": [
-    "zzik2"
+    "zzik2",
+    "CubesterYT"
   ],
   "contact": {
     "homepage": ""

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Mod properties
-mod_version=0.0.9
+mod_version=0.0.10
 maven_group=zzik2
 archives_name=barched
 enabled_platforms=fabric,neoforge

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -7,7 +7,7 @@ license = "MIT"
 modId = "barched"
 version = "${version}"
 displayName = "Barched"
-authors = "zzik2"
+authors = "zzik2, CubesterYT"
 description = '''
 Bringing Parched, Camel Husk and Spears from 1.21.11 to 1.21.1!
 '''


### PR DESCRIPTION
Fixes #21
Fixes #25

A couple of fixes that allows this mod to actually work with sable (the physics engine used by Create: Aeronautics)

Makes `playSound` mixin overrides unique, as not to conflict with Sable, and also use a more reliable entity reach picking method by tapping into the actual mixin directly.

Here's my testing:

https://github.com/user-attachments/assets/6eb127cc-7167-40cb-bcc0-725b3235f693

I attribute swap a lot because I'm top 10 global on spear elytra leaderboards in minemen :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Raycasting/picking updated to use renderer-based detection for more consistent targeting and hit results.

* **Chores**
  * Version bumped to 0.0.10.
  * Updated mod credits (added an additional author).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zzik2/Barched/pull/24)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->